### PR TITLE
Fix interaction with Cyclic Uncrafting Grinder.

### DIFF
--- a/src/main/java/de/canitzp/feederhelmet/FeederHelmet.java
+++ b/src/main/java/de/canitzp/feederhelmet/FeederHelmet.java
@@ -138,6 +138,7 @@ public class FeederHelmet{
                         recipeInputItems.add(Ingredient.of(helmet));
 
                         ItemStack recipeOutputStack = new ItemStack(helmet);
+                        NBTHelper.addModule(module.getTagName(), recipeOutputStack);
 
                         ResourceLocation craftingId = new ResourceLocation(MODID, module.getTagName() + "_" + helmet.getRegistryName().getNamespace() + "_" + helmet.getRegistryName().getPath());
 


### PR DESCRIPTION
The Grinder will take a helmet that does not have the feeder module installed in it and uncraft it into itself and a feeder module, allowing for infinite duplication of the helmet and modules.

The core of this I believe is with how the Uncrafting Grinder works. When provided an item, it should be looking up crafting table recipes for the item to get the recipe and then reverse it. This is where the problem comes in. In the case of lets say a diamond helmet, the recipe seen is the module + the helmet crafting into that same helmet,  while the output of the recipe (what item is actually created) is the helmet plus the feeder module (i.e., the additional NBT tag). This in effect causes an infinite loop. This can be addressed by telling the recipe that the outputted item has the additional NBT tag, which now lets the Uncrafting Grinder work as expected. 